### PR TITLE
Fix include paths for cppjieba headers

### DIFF
--- a/src/hmm_segment.cpp
+++ b/src/hmm_segment.cpp
@@ -1,5 +1,5 @@
 #include "erl_nif.h"
-#include "HMMSegment.hpp"
+#include "cppjieba/HMMSegment.hpp"
 
 cppjieba::HMMSegment* segment = nullptr;
 

--- a/src/mix_segment.cpp
+++ b/src/mix_segment.cpp
@@ -1,5 +1,5 @@
 #include "erl_nif.h"
-#include "MixSegment.hpp"
+#include "cppjieba/MixSegment.hpp"
 
 cppjieba::MixSegment* segment = nullptr;
 

--- a/src/mp_segment.cpp
+++ b/src/mp_segment.cpp
@@ -1,5 +1,5 @@
 #include "erl_nif.h"
-#include "MPSegment.hpp"
+#include "cppjieba/MPSegment.hpp"
 
 cppjieba::MPSegment* segment = nullptr;
 

--- a/src/query_segment.cpp
+++ b/src/query_segment.cpp
@@ -1,5 +1,5 @@
 #include "erl_nif.h"
-#include "QuerySegment.hpp"
+#include "cppjieba/QuerySegment.hpp"
 
 cppjieba::QuerySegment* segment = nullptr;
 


### PR DESCRIPTION
## Summary
- update all NIF source files to include cppjieba headers with correct path

## Testing
- `git submodule update --init`
- `make segment` *(fails: `erl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4dd6824832aa0fffbb9387a2408