### PR TITLE
Include limonp headers for mix compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 ERLANG_PATH:=$(shell erl -eval 'io:format("~s~n", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CPPJIEBA_PATH=priv/libcppjieba/include
+LIMONP_PATH=priv/libcppjieba/deps/limonp/include
 
 CFLAGS=-g -fPIC -O3
 ERLANG_FLAGS=-I$(ERLANG_PATH)
-CPPJIEBA_FLAGS=-I$(CPPJIEBA_PATH)
+CPPJIEBA_FLAGS=-I$(CPPJIEBA_PATH) -I$(LIMONP_PATH)
 CC?=clang
 CXX?=clang++
 EBIN_DIR=ebin
@@ -21,7 +22,7 @@ all:
 	mix compile
 
 libcppjieba_src:
-	git submodule update --init
+	git submodule update --init --recursive
 
 segment: clean libcppjieba_src priv/mp_segment.so priv/hmm_segment.so priv/mix_segment.so priv/query_segment.so
 

--- a/README.org
+++ b/README.org
@@ -6,15 +6,15 @@ Elixir verison of Jieba Base on [[https://github.com/aszxqw/libcppjieba/][libcpp
 Erlang/OTP 22 [erts-10.4.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
 
 rm -rf priv/*_segment.*
-git submodule update --init
+git submodule update --init --recursive
 mkdir -p priv && \
-cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/mp_segment.cpp -o priv/mp_segment.so 2>&1 >/dev/null
+cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -Ipriv/libcppjieba/deps/limonp/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/mp_segment.cpp -o priv/mp_segment.so 2>&1 >/dev/null
 mkdir -p priv && \
-cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/hmm_segment.cpp -o priv/hmm_segment.so 2>&1 >/dev/null
+cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -Ipriv/libcppjieba/deps/limonp/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/hmm_segment.cpp -o priv/hmm_segment.so 2>&1 >/dev/null
 mkdir -p priv && \
-cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/mix_segment.cpp -o priv/mix_segment.so 2>&1 >/dev/null
+cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -Ipriv/libcppjieba/deps/limonp/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/mix_segment.cpp -o priv/mix_segment.so 2>&1 >/dev/null
 mkdir -p priv && \
-cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/query_segment.cpp -o priv/query_segment.so 2>&1 >/dev/null
+cc -g -fPIC -O3 -I/home/falood/.asdf/installs/erlang/22.0.7/erts-10.4.4/include -Ipriv/libcppjieba/include -Ipriv/libcppjieba/deps/limonp/include -shared -lstdc++ -DLOGGER_LEVEL=LL_ERROR src/query_segment.cpp -o priv/query_segment.so 2>&1 >/dev/null
 Interactive Elixir (1.9.1) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)> ExJieba.MixSegment.cut "工信处女干事每月经过下属科室都要亲口交代24口交换机等技术性器件的安装工作"
 ["工信处", "女干事", "每月", "经过", "下属", "科室", "都", "要",


### PR DESCRIPTION
## Summary
- include `priv/libcppjieba/deps/limonp/include` when compiling C++ code
- fetch submodule deps recursively
- update README instructions

## Testing
- `make segment` *(fails: `erl: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_683fe73fd118832ab94cf36e509d9ae3